### PR TITLE
Change GEMINI_API_KEY references to GOOGLE_API_KEY

### DIFF
--- a/docs/workspaces.md
+++ b/docs/workspaces.md
@@ -29,7 +29,7 @@ tspark.json - in root of workspace
       "ANTHROPIC_API_KEY": "xxxxx"
     },
     "gemini": {
-      "GEMINI_API_KEY": "xxxxx"
+      "GOOGLE_API_KEY": "xxxxx"
     },
     "openai": {
       "OPENAI_API_KEY": "xxxxx"

--- a/src/main/llm/geminiLLM.ts
+++ b/src/main/llm/geminiLLM.ts
@@ -125,7 +125,7 @@ export class GeminiLLM implements ILLM {
     try {
       const apiKey = this.workspace.getProviderSettingsValue(LLMType.Gemini, 'GOOGLE_API_KEY')!;
       if (!apiKey) {
-        throw new Error('GEMINI_API_KEY is missing in the configuration. Please add it to your config.json file.');
+        throw new Error('GOOGLE_API_KEY is missing in the configuration. Please add it to your config.json file.');
       }
       this.genAI = new GoogleGenAI({ apiKey });
       log.info('Gemini LLM initialized successfully');


### PR DESCRIPTION
Either the docs and error need to change or the key name needs to change. The truth seems to be `GOOGLE_API_KEY` so I went with that.