### PR TITLE
Add GitHub Action for validating merges and commits to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-nodejs
+
+name: Node.js CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [18.x, 20.x, 22.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: npm ci
+    - run: npm run build --if-present
+# Uncomment the next line when the dev dependencies are fixed to add jest and ts-jest
+#    - run: npm test


### PR DESCRIPTION
This will make sure it at least builds when someone contributes their fine code as a PR. The `npm run test` is commented out because there needs to be a `jest` and probably a `ts-jest` dev dependency. I could pile those in here, but then the `lock` changes in the other PR will probably conflict. Let's shoot ourselves in one foot at a time.